### PR TITLE
fixed compile issues due to wrong (old) dependency version

### DIFF
--- a/dcm4chee-xds2-pix-client/pom.xml
+++ b/dcm4chee-xds2-pix-client/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-common</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dcm4chee-xds2-pix-tool/pom.xml
+++ b/dcm4chee-xds2-pix-tool/pom.xml
@@ -107,12 +107,12 @@
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-common</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-pix-client</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     	<dependency>
       		<groupId>commons-cli</groupId>

--- a/dcm4chee-xds2-src/dcm4chee-xds2-src-base/pom.xml
+++ b/dcm4chee-xds2-src/dcm4chee-xds2-src-base/pom.xml
@@ -65,13 +65,13 @@
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-infoset</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-common</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/dcm4chee-xds2-src/dcm4chee-xds2-src-tool/pom.xml
+++ b/dcm4chee-xds2-src/dcm4chee-xds2-src-tool/pom.xml
@@ -111,19 +111,19 @@
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-infoset</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-common</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.dcm4che</groupId>
             <artifactId>dcm4chee-xds2-src-base</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     	<dependency>

--- a/dcm4chee-xds2-tool/dcm4chee-xds2-tool-init/pom.xml
+++ b/dcm4chee-xds2-tool/dcm4chee-xds2-tool-init/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.dcm4che</groupId>
 			<artifactId>dcm4chee-xds2-infoset</artifactId>
-			<version>2.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
I was not able to compile the project with an empty maven repository. Had to change the versions of some artifacts to the ${project.version}.
